### PR TITLE
fixes LF localizer failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gTTS>=2.2.2
 voxpopuli
 # pyee pinned because of mycroft
 pyee==8.1.0
+lingua_franca>=0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ gTTS>=2.2.2
 voxpopuli
 # pyee pinned because of mycroft
 pyee==8.1.0
-lingua_franca>=0.4.2
+lingua_nostra>=0.4.3

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ PLUGIN_ENTRY_POINT = ('chatterbox_gtts_plug = '
 
 setup(
     name='text2speech',
-    version='0.2.0a1',
+    version='0.2.1a1',
     packages=['text2speech', 'text2speech.modules'],
     url='https://github.com/HelloChatterbox/text2speech',
     license='apache',
@@ -59,6 +59,7 @@ setup(
                       "psutil",
                       "gTTS>=2.2.1",
                       "pyee==8.1.0",
+                      "lingua_franca>=0.4.2"
                       "voxpopuli"],
     author_email='jarbasai@mailfence.com',
     description='TTS engines',

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
                       "psutil",
                       "gTTS>=2.2.1",
                       "pyee==8.1.0",
-                      "lingua_franca>=0.4.2"
+                      "lingua_nostra>=0.4.3"
                       "voxpopuli"],
     author_email='jarbasai@mailfence.com',
     description='TTS engines',

--- a/text2speech/modules/mimic2_tts.py
+++ b/text2speech/modules/mimic2_tts.py
@@ -8,8 +8,8 @@ from requests.exceptions import (
     ReadTimeout, ConnectionError, ConnectTimeout, HTTPError
 )
 
-from lingua_franca.format import pronounce_number
-import lingua_franca.config
+from lingua_nostra.format import pronounce_number
+import lingua_nostra.config
 
 from urllib import parse
 import math
@@ -20,7 +20,7 @@ import json
 
 max_sentence_size = 170
 
-lingua_franca.config.load_langs_on_demand = True
+lingua_nostra.config.load_langs_on_demand = True
 
 
 def break_chunks(l, n):
@@ -260,7 +260,7 @@ class Mimic2(TTS):
             LOG.exception("type error in mimic2_tts.py _normalized_numbers()")
         except ImportError:
             LOG.warning(
-                "lingua_franca not installed, can not normalize numbers")
+                "lingua_nostra not installed, can not normalize numbers")
         return sentence
 
     def get_tts(self, sentence, wav_file):

--- a/text2speech/modules/mimic2_tts.py
+++ b/text2speech/modules/mimic2_tts.py
@@ -7,6 +7,10 @@ from requests_futures.sessions import FuturesSession
 from requests.exceptions import (
     ReadTimeout, ConnectionError, ConnectTimeout, HTTPError
 )
+
+from lingua_franca.format import pronounce_number
+import lingua_franca.config
+
 from urllib import parse
 import math
 import base64
@@ -15,6 +19,8 @@ import re
 import json
 
 max_sentence_size = 170
+
+lingua_franca.config.load_langs_on_demand = True
 
 
 def break_chunks(l, n):
@@ -243,10 +249,9 @@ class Mimic2(TTS):
             stf: normalized sentences to speak
         """
         try:
-            from lingua_franca.format import pronounce_number
             numbers = re.findall(r'-?\d+', sentence)
             normalized_num = [
-                (num, pronounce_number(int(num)))
+                (num, pronounce_number(int(num), lang=self.lang))
                 for num in numbers
             ]
             for num, norm_num in normalized_num:
@@ -254,7 +259,8 @@ class Mimic2(TTS):
         except TypeError:
             LOG.exception("type error in mimic2_tts.py _normalized_numbers()")
         except ImportError:
-            LOG.warning("lingua_franca not installed, can not normalize numbers")
+            LOG.warning(
+                "lingua_franca not installed, can not normalize numbers")
         return sentence
 
     def get_tts(self, sentence, wav_file):
@@ -339,4 +345,3 @@ class Mimic2Validator(TTSValidator):
 
     def get_tts_class(self):
         return Mimic2
-


### PR DESCRIPTION
MycroftAI/lingua-franca/#158 enables this, which addresses a breaking change that causes the Mimic2 module to crash on Lingua Franca 0.3+.

Also bumps the version.

**Note**: this depends on the aforementioned (currently unmerged) LF branch. `text2speech/requirements.txt` is currently pinned to the PR branch *at my LF repo*, which should be fixed when the linked PR is merged at LF.